### PR TITLE
chore: Migrate to java-builder image

### DIFF
--- a/.github/workflows/jicmp6-build.yaml
+++ b/.github/workflows/jicmp6-build.yaml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/bluebird/jicmp-builder:0.0.1.b1
+      image: quay.io/bluebird/java-builder:0.0.3.jdk-8
     steps:
       - uses: actions/checkout@v4
         with:
@@ -45,7 +45,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     container:
-      image: quay.io/bluebird/jicmp-builder:0.0.1.b1
+      image: quay.io/bluebird/java-builder:0.0.3.jdk-8
     steps:
       - uses: actions/download-artifact@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,7 @@ package-lock.json
 /public/
 /tmp/
 /docs-src/antora.yml
+
+# Intellij IDEA
+.idea/
+


### PR DESCRIPTION
The java builder image can be used for generic builds and a specific JICMP builder isn't required anymore.